### PR TITLE
Use shopify.com domain restriction for OAuth.

### DIFF
--- a/config/initializers/google_auth.rb
+++ b/config/initializers/google_auth.rb
@@ -1,1 +1,1 @@
-Forage::Application.config.google_auth.domain = 'jadedpixel.com'
+Forage::Application.config.google_auth.domain = 'shopify.com'


### PR DESCRIPTION
Use shopify.com domain for OAuth. r: @edward =)
